### PR TITLE
GNOME friendly icons

### DIFF
--- a/src/Downloader.vala
+++ b/src/Downloader.vala
@@ -130,7 +130,7 @@ namespace Downloader {
 
         if (name in installed) {
             remove (name, false);
-            button.image = new Gtk.Image.from_icon_name ("browser-download-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            button.image = new Gtk.Image.from_icon_name ("folder-download-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
             button.get_style_context ().remove_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
             for (int i =0; i < installed.length; i++) {
@@ -165,7 +165,7 @@ namespace Downloader {
                 button.image = new Gtk.Image.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
                 button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
             } else {
-                button.image = new Gtk.Image.from_icon_name ("browser-download-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+                button.image = new Gtk.Image.from_icon_name ("folder-download-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
             }
 
             button.clicked.connect (() => {

--- a/src/quickDocs.vala
+++ b/src/quickDocs.vala
@@ -395,7 +395,13 @@ public class App : Gtk.Application {
             }
         });
 
-        var theme_button = new Button.from_icon_name ("object-inverse");
+        var current_icons = Gtk.IconTheme.get_default ();
+        string icon_name = "object-inverse";
+        if (current_icons.lookup_icon (icon_name, 16, Gtk.IconLookupFlags.FORCE_SIZE) == null) {
+            icon_name = "weather-few-clouds-symbolic";
+        }
+
+        var theme_button = new Button.from_icon_name (icon_name);
         theme_button.clicked.connect(() => {
             toggle_theme (dev, online);
         });


### PR DESCRIPTION
Use GNOME-friendly icons where possible, and use a fallback where there's no replacement
fixes #32 