### PR TITLE
Add link to repo containing opensuse package

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A fast developer docs reader
 ## Install:
  - For Debian / Ubuntu based systems, install the latest .deb from [here](https://github.com/mdh34/quickDocs/releases) (64-bit only)
  - For Arch Linux based systems, install the AUR package from [here](https://aur.archlinux.org/packages/quickdocs/)
+ - For OpenSUSE Leap/Tumbleweed, add the following [repo](https://build.opensuse.org/package/show/home:MichaelAquilina/quickdocs)
 
 ## Install From Source:
 The following instructions should work on most debian-based systems:


### PR DESCRIPTION
I build this project in my personal opensuse repo, so now that package is easily installable from there

```
sudo zypper addrepo https://download.opensuse.org/repositories/home:/MichaelAquilina/openSUSE_Tumbleweed/ MichaelAquilina
sudo zypper refresh
sudo zypper install quickdocs
```

I'll suggest adding it to the main tumbleweed repo by posting on the mailing list. If it gets accepted, I'll update the README to reflect that.