### PR TITLE
Change Category to Development;Documentation;

### DIFF
--- a/data/com.github.mdh34.quickdocs.desktop.in
+++ b/data/com.github.mdh34.quickdocs.desktop.in
@@ -2,7 +2,7 @@
 Name=quickDocs
 GenericName=quickDocs
 Comment=A fast developer docs reader that supports Valadoc and DevDocs
-Categories=Development;
+Categories=Development;Documentation;
 Exec=com.github.mdh34.quickdocs
 Icon=com.github.mdh34.quickdocs
 Terminal=false


### PR DESCRIPTION
OpenSUSEs build service linter was complaining that the category was not correct.

According to their list we can use `Development;Documentation;` https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories