### PR TITLE
Added Flatpak manifest for elementary

### DIFF
--- a/com.github.mdh34.quickdocs.yml
+++ b/com.github.mdh34.quickdocs.yml
@@ -1,0 +1,35 @@
+app-id: com.github.mdh34.quickdocs
+runtime: io.elementary.Platform
+runtime-version: '6'
+sdk: io.elementary.Sdk
+command: com.github.mdh34.quickdocs
+finish-args:
+  - '--share=ipc'
+  - '--share=network'
+  - '--device=dri'
+  - '--socket=x11'
+  - '--socket=wayland'
+  - '--talk-name=org.gtk.vfs.*'
+  - '--metadata=X-DConf=migrate-path=/com/github/mdh34/quickdocs/'
+modules:
+  - name: libdevhelp
+    buildsystem: meson
+    config-opts:
+      - '-Dflatpak_build=true'
+    sources:
+      - type: archive
+        url: https://gitlab.gnome.org/GNOME/devhelp/-/archive/3.34.0/devhelp-3.34.0.tar.gz
+        sha256: a3fbe7a7e40352d5aa72454fa5752e8616cb6636a7c38df9466384c186f03216
+    modules:
+      - name: amtk-5
+        sources:
+          - type: archive
+            url: https://download.gnome.org/sources/amtk/5.0/amtk-5.0.1.tar.xz
+            sha256: 2d1cf4a4468655f93c90a2dde2e08b1ea0b3960c0aee04eb206c201d7849de27
+  - name: quickdocs
+    buildsystem: meson
+    config-opts:
+      - '--buildtype=release'
+    sources:
+      - type: dir
+        path: .


### PR DESCRIPTION
I took the existing manifest from Flathub and modified it slightly to be compatible with the new release of elementary OS 6.0 and it's AppCenter. I see that you already have the app previously published in the AppCenter, but all apps now are required to be Flatpak apps.

By merging this PR your app will now be compatible with the new release of AppCenter, but you still need to submit a PR to have your app submission reiewed by the elementary developers. The PR
needs to be made here:

 * https://github.com/elementary/appcenter-reviews/pulls

Step by step details are available here:

 * https://docs.elementary.io/develop/appcenter/submission-process

For the most part these are the steps:

 1. add your Stripe key to `appdata.xml`
 2. publish a new release
 3. make a pull request to https://github.com/elementary/appcenter-reviews
